### PR TITLE
Take the maximum stack size from the slot when extracting from large slots

### DIFF
--- a/src/main/java/org/cyclops/commoncapabilities/ingredient/storage/IngredientComponentStorageWrapperHandlerItemStack.java
+++ b/src/main/java/org/cyclops/commoncapabilities/ingredient/storage/IngredientComponentStorageWrapperHandlerItemStack.java
@@ -257,8 +257,12 @@ public class IngredientComponentStorageWrapperHandlerItemStack<C>
         protected ItemStack storageExtractItem(int slot, int amount, boolean simulate) {
             // Special handling for inventories that have larger slot sizes, such as Sophisticated Barrels.
             // See https://github.com/CyclopsMC/IntegratedCrafting/issues/106
-            int maxStackSize = ItemStack.EMPTY.getMaxStackSize();
-            if (amount > maxStackSize && storage.getSlotLimit(slot) > maxStackSize) {
+            // The maximum stack size has to come from the stack in the slot:
+            // item handlers cap a single extraction at the stack's own maximum,
+            // and ItemStack.EMPTY has no max stack size component, so it reports 1.
+            ItemStack stackInSlot = storage.getStackInSlot(slot);
+            int maxStackSize = stackInSlot.getMaxStackSize();
+            if (!stackInSlot.isEmpty() && amount > maxStackSize && storage.getSlotLimit(slot) > maxStackSize) {
                 if (simulate) {
                     // In simulate-mode, extract up to max stack size.
                     // If the returned stack less than max stack size, return it.
@@ -267,11 +271,11 @@ public class IngredientComponentStorageWrapperHandlerItemStack<C>
                     if (extractedUntilMaxStackSize.getCount() < maxStackSize) {
                         return extractedUntilMaxStackSize;
                     } else {
-                        ItemStack stackInSlot = storage.getStackInSlot(slot).copy();
-                        if (stackInSlot.getCount() > amount) {
-                            stackInSlot.setCount(amount);
+                        ItemStack extractedFullSlot = stackInSlot.copy();
+                        if (extractedFullSlot.getCount() > amount) {
+                            extractedFullSlot.setCount(amount);
                         }
-                        return stackInSlot;
+                        return extractedFullSlot;
                     }
                 } else {
                     // Iterate extraction until requested amount is reached.

--- a/src/test/java/org/cyclops/commoncapabilities/ingredient/storage/TestItemStackComponentStorageWrapper.java
+++ b/src/test/java/org/cyclops/commoncapabilities/ingredient/storage/TestItemStackComponentStorageWrapper.java
@@ -342,4 +342,75 @@ public class TestItemStackComponentStorageWrapper {
         assertThat(eq(storageLarge.getStackInSlot(0), APPLE_60), is(true));
     }
 
+
+    /**
+     * An item handler with a drawer-like slot capacity, that counts how often it is asked to extract.
+     */
+    private static class CountingItemStackHandler extends ItemStackHandler {
+
+        private final int slotLimit;
+        private int extractCalls = 0;
+
+        public CountingItemStackHandler(int slotLimit) {
+            super(1);
+            this.slotLimit = slotLimit;
+        }
+
+        public int getExtractCalls() {
+            return extractCalls;
+        }
+
+        @Override
+        public int getSlotLimit(int slot) {
+            return slotLimit;
+        }
+
+        @Override
+        @Nonnull
+        public ItemStack extractItem(int slot, int amount, boolean simulate) {
+            extractCalls++;
+            return super.extractItem(slot, amount, simulate);
+        }
+    }
+
+    /**
+     * Item handlers cap a single extraction at the stack's own maximum stack size,
+     * so a slot holding more than that has to be drained in multiple calls.
+     * Those calls must be full stacks, not single items.
+     */
+    @Test
+    public void testExtractLargeUsesFullStacksPerHandlerCall() {
+        CountingItemStackHandler storageCounting = new CountingItemStackHandler(4096);
+        storageCounting.setStackInSlot(0, new ItemStack(Items.APPLE, 1000));
+        IngredientComponentStorageWrapperHandlerItemStack.ComponentStorageWrapper wrapperCounting =
+                new IngredientComponentStorageWrapperHandlerItemStack.ComponentStorageWrapper(
+                        IngredientComponents.ITEMSTACK, storageCounting);
+
+        ItemStack extracted = wrapperCounting.extract(new ItemStack(Items.APPLE, 1000),
+                ItemMatch.ITEM | ItemMatch.STACKSIZE, false);
+
+        assertThat(extracted.getCount(), is(1000));
+        // 1000 apples is 16 stacks of 64, plus a simulated call, so this is comfortably above the ideal
+        assertThat(storageCounting.getExtractCalls() < 40, is(true));
+    }
+
+    /**
+     * The same, for an item whose maximum stack size is below 64.
+     */
+    @Test
+    public void testExtractLargeUsesFullStacksPerHandlerCallForSmallStacks() {
+        CountingItemStackHandler storageCounting = new CountingItemStackHandler(4096);
+        storageCounting.setStackInSlot(0, new ItemStack(Items.ENDER_PEARL, 200));
+        IngredientComponentStorageWrapperHandlerItemStack.ComponentStorageWrapper wrapperCounting =
+                new IngredientComponentStorageWrapperHandlerItemStack.ComponentStorageWrapper(
+                        IngredientComponents.ITEMSTACK, storageCounting);
+
+        ItemStack extracted = wrapperCounting.extract(new ItemStack(Items.ENDER_PEARL, 100),
+                ItemMatch.ITEM | ItemMatch.STACKSIZE, false);
+
+        assertThat(extracted.getCount(), is(100));
+        // Ender pearls stack to 16, so 100 of them is 7 stacks
+        assertThat(storageCounting.getExtractCalls() < 20, is(true));
+    }
+
 }


### PR DESCRIPTION
## Problem

`IngredientComponentStorageWrapperHandlerItemStack.ComponentStorageWrapper.storageExtractItem` is the workaround for inventories whose slots hold more than a vanilla stack (added for CyclopsMC/IntegratedCrafting#106, Sophisticated Barrels). It read its "one vanilla stack" value from `ItemStack.EMPTY`:

```java
int maxStackSize = ItemStack.EMPTY.getMaxStackSize();
```

Since the data component rewrite that returns **1**, not 64. `ItemStack.getComponents()` returns `DataComponentMap.EMPTY` for an empty stack, so NeoForge's `IItemExtension.getMaxStackSize(stack)` falls through to `getOrDefault(DataComponents.MAX_STACK_SIZE, 1)`. Confirmed at runtime on 1.21.1 / NeoForge 21.1.247.

Two consequences:

1. The branch now triggers for practically every extraction, since `amount > 1 && getSlotLimit(slot) > 1` holds for any ordinary chest.
2. The non-simulated path loops on `Math.min(amount - count, maxStackSize)`, so it pulls **one item per `extractItem` call**. Measured with a counting handler: draining 1000 items out of one 4096-capacity slot took **1001** calls where 16 would do.

Items that stack below 64 were affected the same way even before this, since the constant never matched their actual cap. 100 ender pearls took ~101 calls rather than 7.

## Cost

Measured against real block entities: extracting **1024 oak planks in a single `extract` call**, 1 warmup then 3 timed runs, reported as the mean per run, whole configuration repeated twice. Before = stock `2.11.5-363`, after = this branch published locally as `2.11.5-DEV`; the mod list in each log confirms which jar loaded.

| storage | before | after | speedup |
|---|---|---|---|
| Sophisticated Storage `limited_diamond_barrel_1` (1 slot, 8192 capacity) | 7.87 ms / 7.74 ms | 0.43 ms / 0.37 ms | **~20x** |
| vanilla chest (27 slots x 64) | 2.79 ms / 2.06 ms | 0.18 ms / 0.20 ms | **~11-15x** |

At the old rate, draining a full 8192-capacity barrel slot in one extraction extrapolates to roughly **62 ms**, more than a whole 50 ms server tick, for a single call. After the change that is about 3 ms.

Vanilla chests were affected too, ~11-15x, which confirms the branch was triggering for essentially every extraction rather than only for oversized slots. This was never drawer-specific.

Caveat on the numbers: n is small and these are dev-environment measurements on a single machine, so treat them as an order of magnitude rather than a precise figure. The variance across repeats is small relative to the effect.

## Change

Take the maximum stack size from the stack in the slot, which is what item handlers actually cap a single extraction at (`ItemStackHandler.extractItem` does `Math.min(amount, existing.getMaxStackSize())`). An empty slot falls through to the plain `extractItem` as before, rather than short-circuiting, so handlers with an unusual `getStackInSlot` keep their old behaviour.

## Tests

Two additions to `TestItemStackComponentStorageWrapper`, using a counting `ItemStackHandler` with a drawer-like slot limit:

- `testExtractLargeUsesFullStacksPerHandlerCall`: 1000 apples out of one slot, asserts the extraction is correct and takes fewer than 40 handler calls.
- `testExtractLargeUsesFullStacksPerHandlerCallForSmallStacks`: the same for ender pearls, which stack to 16.

Both fail on `master-1.21-lts` and pass with the change. The existing `testExtractLarge` and `testExtractLargePartial` pass either way, since the old code was correct, just slow.

## Validation

- `./gradlew build` passes
- `./gradlew runGameTestServer --rerun` passes, 47 game tests

Note for anyone building this locally: `src/main/java/org/cyclops/commoncapabilities/api` is a git submodule, and `compileJava` fails with 223 errors until `git submodule update --init` has been run. That is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACuxaa5QeiZ8mVsEQtwSq1